### PR TITLE
Open all files for write in binary mode

### DIFF
--- a/itstool.in
+++ b/itstool.in
@@ -1577,7 +1577,7 @@ if __name__ == '__main__':
             if opts.output == '-':
                 out = sys.stdout
             else:
-                out = open(opts.output, 'w')
+                out = open(opts.output, 'wb')
         else:
             sys.stderr.write('Error: Non-directory output for multiple files\n')
             sys.exit(1)
@@ -1621,9 +1621,9 @@ if __name__ == '__main__':
         if opts.output is None:
             out = sys.stdout
         elif os.path.isdir(opts.output):
-            out = open(os.path.join(opts.output, os.path.basename(filename)), 'w')
+            out = open(os.path.join(opts.output, os.path.basename(filename)), 'wb')
         else:
-            out = open(opts.output, 'w')
+            out = open(opts.output, 'wb')
         messages = MessageList()
         doc = Document(opts.join, messages)
         doc.apply_its_rules(not(opts.nobuiltins), params=params)
@@ -1640,5 +1640,5 @@ if __name__ == '__main__':
                 sys.exit(1)
             fout = out
             if isinstance(fout, string_types):
-                fout = open(os.path.join(fout, os.path.basename(filename)), 'w')
+                fout = open(os.path.join(fout, os.path.basename(filename)), 'wb')
             fout.write(doc._doc.serialize('utf-8'))


### PR DESCRIPTION
Fixes issue #19 

with this, I was able to build pitivi (the one identified in issue #19 as failing) as well as the entire GNOME stack (3.27.x) using itstool/python3

Comments welcome