### PR TITLE
Fix macOS file writing, and also attribute spacePreserve

### DIFF
--- a/itstool.in
+++ b/itstool.in
@@ -1580,7 +1580,7 @@ if __name__ == '__main__':
             if opts.output == '-':
                 out = sys.stdout
             else:
-                out = open(opts.output, 'w')
+                out = open(opts.output, 'wb')
         else:
             sys.stderr.write('Error: Non-directory output for multiple files\n')
             sys.exit(1)
@@ -1597,10 +1597,10 @@ if __name__ == '__main__':
                 sys.stderr.write('Error: Could not merge translations:\n%s\n' % ustr(e))
                 sys.exit(1)
             serialized = doc._doc.serialize('utf-8')
-            #if PY3:
+            if PY3:
                 # For some reason, under py3, our serialized data is returns as a str.
                 # Let's encode it to bytes
-                #serialized = serialized.encode('utf-8')
+                serialized = serialized.encode('utf-8')
             fout = out
             fout_is_str = isinstance(fout, string_types)
             if fout_is_str:

--- a/itstool.in
+++ b/itstool.in
@@ -1560,6 +1560,7 @@ if __name__ == '__main__':
             doc.output_test_data(opts.test, out)
         else:
             messages.output(out)
+            out.flush()
     elif opts.merge is not None:
         try:
             translations = gettext.GNUTranslations(open(opts.merge, 'rb'))
@@ -1605,6 +1606,7 @@ if __name__ == '__main__':
             if fout_is_str:
                 fout = open(os.path.join(fout, os.path.basename(filename)), 'wb')
             fout.write(serialized)
+            fout.flush()
             if fout_is_str:
                 fout.close()
     elif opts.join is not None:
@@ -1644,3 +1646,4 @@ if __name__ == '__main__':
             if isinstance(fout, string_types):
                 fout = open(os.path.join(fout, os.path.basename(filename)), 'w')
             fout.write(doc._doc.serialize('utf-8'))
+            fout.flush()

--- a/itstool.in
+++ b/itstool.in
@@ -1164,6 +1164,8 @@ class Document (object):
             for attr in xml_attr_iter(node):
                 if self._its_translate_nodes.get(attr, 'no') == 'yes':
                     attr_msg = Message()
+                    if self.get_preserve_space(attr):
+                        attr_msg.set_preserve_space()
                     attr_msg.add_source('%s:%i' % (self._doc.name, node.lineNo()))
                     attr_msg.add_marker('%s/%s@%s' % (node.parent.name, node.name, attr.name))
                     attr_msg.add_text(attr.content)

--- a/itstool.in
+++ b/itstool.in
@@ -1594,10 +1594,10 @@ if __name__ == '__main__':
                 sys.stderr.write('Error: Could not merge translations:\n%s\n' % ustr(e))
                 sys.exit(1)
             serialized = doc._doc.serialize('utf-8')
-            if PY3:
+            #if PY3:
                 # For some reason, under py3, our serialized data is returns as a str.
                 # Let's encode it to bytes
-                serialized = serialized.encode('utf-8')
+                #serialized = serialized.encode('utf-8')
             fout = out
             fout_is_str = isinstance(fout, string_types)
             if fout_is_str:


### PR DESCRIPTION
1. I use macOS and installed python3 using brew. Some things seem to be fixed in python3.7, specifically the need to encode to bytes in serialization.
2. Also, the script wasn't writing to the files since there was no flushing.
3. Also added a check of spacePreserve when adding attributes to the message.