### PR TITLE
Use the same python executable in run_tests.py as far as possible

### DIFF
--- a/tests/run_tests.py
+++ b/tests/run_tests.py
@@ -6,10 +6,12 @@ import unittest
 
 TEST_DIR    = os.path.dirname(os.path.abspath(__file__))
 ITSTOOL_DIR = os.path.dirname(TEST_DIR)
-if sys.version_info[0] == 3:
-    PYTHON = 'python3'
-else:
-    PYTHON = 'python2'
+PYTHON      = sys.executable
+if not PYTHON:
+    if sys.version_info[0] == 3:
+        PYTHON = 'python3'
+    else:
+        PYTHON = 'python2'
 
 class ItstoolTests(unittest.TestCase):
     def tearDown(self):


### PR DESCRIPTION
The purpose of this pull-request is completely same as #39 .
But this leaves hardcoding as a fallback in case [sys.executable] is an empty string or None.

[sys.executable]: https://docs.python.org/3/library/sys.html?highlight=sys.executable#sys.executable