### PR TITLE
Fix regex processing with python 3.12

### DIFF
--- a/itstool.in
+++ b/itstool.in
@@ -220,7 +220,7 @@ class Message (object):
         if not isinstance(text, ustr_type):
             text = ustr(text, 'utf-8')
         self._message[-1] += text.replace('&', '&amp;').replace('<', '&lt;').replace('>', '&gt;')
-        if re.sub('\s+', ' ', text).strip() != '':
+        if re.sub(r'\s+', ' ', text).strip() != '':
             self._empty = False
 
     def add_entity_ref (self, name):
@@ -318,7 +318,7 @@ class Message (object):
                 message += '<_:%s-%i/>' % (msg.name, placeholder)
                 placeholder += 1
         if not self._preserve:
-            message = re.sub('\s+', ' ', message).strip()
+            message = re.sub(r'\s+', ' ', message).strip()
         return message
 
     def get_preserve_space (self):
@@ -456,9 +456,9 @@ class LocNote (object):
             if self._preserve_space:
                 return self.locnote
             else:
-                return re.sub('\s+', ' ', self.locnote).strip()
+                return re.sub(r'\s+', ' ', self.locnote).strip()
         elif self.locnoteref is not None:
-            return '(itstool) link: ' + re.sub('\s+', ' ', self.locnoteref).strip()
+            return '(itstool) link: ' + re.sub(r'\s+', ' ', self.locnoteref).strip()
         return ''
 
 
@@ -889,7 +889,7 @@ class Document (object):
         trans = translations.ugettext('_\x04translator-credits')
         if trans is None or trans == 'translator-credits':
             return
-        regex = re.compile('(.*) \<(.*)\>, (.*)')
+        regex = re.compile(r'(.*) \<(.*)\>, (.*)')
         for credit in trans.split('\n'):
             match = regex.match(credit)
             if not match:
@@ -924,7 +924,7 @@ class Document (object):
             prevnode = None
             if node.prev is not None and node.prev.type == 'text':
                 prevtext = node.prev.content
-                if re.sub('\s+', '', prevtext) == '':
+                if re.sub(r'\s+', '', prevtext) == '':
                     prevnode = node.prev
             for lang in sorted(list(translations.keys()), reverse=True):
                 locale = self.get_its_locale_filter(node)
@@ -1468,7 +1468,7 @@ def match_locale(extrange, locale):
         localei += 1
     return True
 
-_locale_pattern = re.compile('([a-zA-Z0-9-]+)(_[A-Za-z0-9]+)?(@[A-Za-z0-9]+)?(\.[A-Za-z0-9]+)?')
+_locale_pattern = re.compile(r'([a-zA-Z0-9-]+)(_[A-Za-z0-9]+)?(@[A-Za-z0-9]+)?(\.[A-Za-z0-9]+)?')
 def convert_locale (locale):
     # Automatically convert POSIX-style locales to BCP47
     match = _locale_pattern.match(locale)


### PR DESCRIPTION
I see an error spam when building Epiphany with itstool 2.0.7-5.fc39:

```
[42/297] Generating help/gl/help-epiphany-gl with a custom command
/usr/bin/itstool:236: SyntaxWarning: invalid escape sequence '\s'
  if re.sub('\s+', ' ', text).strip() != '':
/usr/bin/itstool:334: SyntaxWarning: invalid escape sequence '\s'
  message = re.sub('\s+', ' ', message).strip()
/usr/bin/itstool:472: SyntaxWarning: invalid escape sequence '\s'
  return re.sub('\s+', ' ', self.locnote).strip()
/usr/bin/itstool:474: SyntaxWarning: invalid escape sequence '\s'
  return '(itstool) link: ' + re.sub('\s+', ' ', self.locnoteref).strip()
/usr/bin/itstool:905: SyntaxWarning: invalid escape sequence '\<'
  regex = re.compile('(.*) \<(.*)\>, (.*)')
/usr/bin/itstool:940: SyntaxWarning: invalid escape sequence '\s'
  if re.sub('\s+', '', prevtext) == '':
/usr/bin/itstool:1484: SyntaxWarning: invalid escape sequence '\.'
  _locale_pattern = re.compile('([a-zA-Z0-9-]+)(_[A-Za-z0-9]+)?(@[A-Za-z0-9]+)?(\.[A-Za-z0-9]+)?')
```

Problem is what were intended to be regex escapes are instead being treated as invalid python string escapes. To get a regex escape, we need to either escape the escape, i.e. use `'\\s+'` instead of `\s+'`, or -- better -- use raw string notation, `r'\s+'`.

There's a warning about this in the python 3.12 release notes, https://docs.python.org/3.12/whatsnew/3.12.html ("A backslash-character pair that is not a valid escape sequence now generates a SyntaxWarning, instead of DeprecationWarning.")